### PR TITLE
Deprecated tokens

### DIFF
--- a/archetypes/key/index.md
+++ b/archetypes/key/index.md
@@ -3,6 +3,7 @@ title: "{{ replace .Name "-" " " }}"
 draft: true
 vendor: Vendor
 vendor_link: null
+deprecated: false
 purchase:
   amazon: null
   vendor: null

--- a/content/keys/google-titan-key-gen1/index.md
+++ b/content/keys/google-titan-key-gen1/index.md
@@ -14,22 +14,23 @@ interfaces:
   - usba
   - bluetooth
   - nfc
-Summary: No longer supported, but comprehensive solution to account security. 
+Summary: No longer supported, the first generation of Google's Titan keys started the trend.
 ---
 
 Google's first generation Titan Keys were introduced under their Advanced Protection program. 
 The pair of keys, a Bluetooth/USB and USB A + NFC set, were sold for $50. 
 
 
-The keys are safe, however they are not recommended for new installations. Google has not issued
-further Bluetooth U2F tokens in their later generations, saying in an [announcement](https://security.googleblog.com/2021/08/simplifying-titan-security-key-options.html):
-
-{{< blockquote >}} 
-Since NFC functionality is now supported by a wide range of Android phones and iPhones, we are discontinuing the Bluetooth Titan Security Key and focusing on the easier and more widely available NFC capability. However, for existing users with our Bluetooth Titan Security Keys, these will continue to work with Bluetooth and will continue to work as an NFC key on most modern mobile devices. Applicable warranties for existing Bluetooth Titan Security Keys will continue to be honored per their terms. All Titan Security Keys are built with a hardware secure element chip that includes firmware engineered by Google to verify the key’s integrity.
-{{< /blockquote >}}
-
 These keys were found to have a vulnerability in the Bluetooth dongle: According to a
 [Google Security Blog post](https://security.googleblog.com/2019/05/titan-keys-update.html), the
 Bluetooth tokens are vulnerable to an attack which requires proximity (about 30 feet) and
 prior knowledge of some parts of the user's credentials already, on top of having a very small
 time window.
+
+The non-Bluetooth keys are safe, however they are not recommended for new installations. The [Generation 3](../google-titan-key-gen3/) keys are recommended instead.
+Google has not included Bluetooth U2F tokens in their later generations, saying in an [announcement](https://security.googleblog.com/2021/08/simplifying-titan-security-key-options.html):
+
+{{< blockquote >}} 
+Since NFC functionality is now supported by a wide range of Android phones and iPhones, we are discontinuing the Bluetooth Titan Security Key and focusing on the easier and more widely available NFC capability. However, for existing users with our Bluetooth Titan Security Keys, these will continue to work with Bluetooth and will continue to work as an NFC key on most modern mobile devices. Applicable warranties for existing Bluetooth Titan Security Keys will continue to be honored per their terms. All Titan Security Keys are built with a hardware secure element chip that includes firmware engineered by Google to verify the key’s integrity.
+{{< /blockquote >}}
+

--- a/content/keys/google-titan-key-gen1/index.md
+++ b/content/keys/google-titan-key-gen1/index.md
@@ -3,6 +3,7 @@ title: "Titan Key (Gen1)"
 draft: false
 vendor: google
 vendor_link: https://cloud.google.com/titan-security-key/
+deprecated: true
 purchase:
   amazon: null
   vendor: null

--- a/content/keys/google-titan-key-gen3/index.md
+++ b/content/keys/google-titan-key-gen3/index.md
@@ -3,6 +3,7 @@ title: "Titan Security Key (Gen3)"
 draft: false
 vendor: google
 vendor_link: https://cloud.google.com/titan-security-key/
+deprecated: false
 purchase:
   amazon: null
   vendor: https://store.google.com/product/titan_security_key
@@ -17,6 +18,4 @@ interfaces:
 summary: Google's current generation of U2F tokens, the third generation continues the tradition.
 ---
 
-Google's Third generation FIDO U2F tokens, branded under their Google Cloud program, are produced by FeiTian, coming in either USB-A or USB-C form factors.
-
-Both support NFC. Unlike the first generation, there is no Bluetooth version. Also unlike their OEM counterparts, they *only* support U2F. 
+Google's Third generation FIDO U2F tokens, branded under their Google Cloud program, are produced by FeiTian -- a custom version of the [FeiTian ePASS NFC](../feitian-epass-nfc/) tokens -- coming in either USB-A or USB-C form factors. Both support NFC. Unlike the first generation, there is no Bluetooth version. Unlike their OEM counterparts, they *only* support U2F.

--- a/content/keys/thetis-fido2/index.md
+++ b/content/keys/thetis-fido2/index.md
@@ -3,6 +3,7 @@ title: Thetis FIDO2 Security key
 draft: false
 vendor: thetis
 vendor_link: https://thetis.io/
+deprecated: false
 purchase:
   amazon: B07RL99HZ6
   vendor: https://thetis.io/products/thetis-fido2-security-key

--- a/layouts/keys/single.html
+++ b/layouts/keys/single.html
@@ -14,6 +14,10 @@
 </nav>
 
 <div class="container col-xxl-8 px-4 py-5">
+  {{ if .Params.Deprecated }}<div class="alert alert-warning" role="alert">
+    This key is no longer recommended for daily use, and should not be used in new deployments. This information is considered historical. 
+  </div>{{- end -}}
+
   <div class="row flex-lg-row-reverse align-items-center g-5 py-5">
     <div class="col-10 col-sm-8 col-lg-6">
       {{$feature := .Resources.GetMatch "feature*" }}
@@ -24,9 +28,6 @@
       {{- end -}}
     </div>
     <div class="col-lg-6">
-      {{ if .Params.Deprecated }}<div class="alert alert-danger" role="alert">
-        This key is no longer recommended for daily use.   
-      </div>{{- end -}}
       <h1 class="display-5 fw-bold lh-1 mb-3">{{.Title}}</h1>
       {{if .Params.Lead }}
       {{with .Params.Lead}}
@@ -37,10 +38,10 @@
       {{- end -}}
       <div class="d-grid gap-2">
         {{with .Params.vendor_link}}<a type="button" href="{{.}}" class="btn btn-primary btn-lg px-4 me-md-2">Vendor Website</a>{{end}}
-        
+        {{if not .Params.Deprecated }}
         {{with .Params.purchase.vendor}}<a type="button" href="{{.}}" class="btn btn-secondary btn-lg px-4 me-md-2">Purchase from {{$vendor.Title}}</a>{{end}}
         {{with .Params.purchase.amazon}}<a type="button" href="https://amazon.com/dp/{{.}}/" class="btn btn-secondary btn-lg px-4 me-md-2">Purchase on Amazon</a>{{end}}
-
+        {{- end -}}
       </div>
     </div>
   </div>

--- a/layouts/keys/single.html
+++ b/layouts/keys/single.html
@@ -24,6 +24,9 @@
       {{- end -}}
     </div>
     <div class="col-lg-6">
+      {{ if .Params.Deprecated }}<div class="alert alert-danger" role="alert">
+        This key is no longer recommended for daily use.   
+      </div>{{- end -}}
       <h1 class="display-5 fw-bold lh-1 mb-3">{{.Title}}</h1>
       {{if .Params.Lead }}
       {{with .Params.Lead}}

--- a/layouts/keys/single.html
+++ b/layouts/keys/single.html
@@ -23,6 +23,7 @@
       {{$feature := .Resources.GetMatch "feature*" }}
       {{if $feature -}}
       {{$resized := $feature.Fit "700x500"}}
+      {{- if .Params.Deprecated }}{{ $resized = $resized.Filter images.Grayscale }}{{ end -}}
       <img src="{{$resized.RelPermalink}}" class="d-block mx-lg-auto img-fluid" alt="Bootstrap Themes" width="700" height="500" loading="lazy">
       {{- else -}}
       {{- end -}}

--- a/layouts/partials/keys.html
+++ b/layouts/partials/keys.html
@@ -10,6 +10,7 @@
           {{$resized := .Fill "400x400" -}}
           <img src="{{ $resized.RelPermalink }}" class="card-img-top" alt="{{$pgTitle}}">
           {{- end -}}
+          {{- with .Params.Deprecated -}}{{- if . }}<div class="card-body text-dark bg-warning">This key is no longer recommended for use.</div>{{- end -}}{{- end -}}
           <div class="card-body">
               <h3 class="card-title">{{$pgTitle}}</h3>
               {{with .Summary -}}

--- a/layouts/partials/keys.html
+++ b/layouts/partials/keys.html
@@ -6,8 +6,10 @@
     <div class="mb-3">
         {{$pgTitle := .Page.Title }}
         <div class="card">
+          {{$pg := . }}
           {{- with .Page.Resources.GetMatch "feature*" }}
           {{$resized := .Fill "400x400" -}}
+          {{- with $pg.Params.Deprecated -}}{{- if . }}{{ $resized = $resized.Filter images.Grayscale }}{{ end }}{{ end -}}
           <img src="{{ $resized.RelPermalink }}" class="card-img-top" alt="{{$pgTitle}}">
           {{- end -}}
           {{- with .Params.Deprecated -}}{{- if . }}<div class="card-body text-dark bg-warning">This key is no longer recommended for use.</div>{{- end -}}{{- end -}}


### PR DESCRIPTION
Closes #1 - Enables clarifying that a key is no longer supported and should not be used in new deployments. 